### PR TITLE
Comments not returned when loading a PLY file

### DIFF
--- a/source/tinyply.cpp
+++ b/source/tinyply.cpp
@@ -77,7 +77,7 @@ bool PlyFile::parse_header(std::istream& is)
         else if (token == "format")     read_header_format(ls);
         else if (token == "element")    read_header_element(ls);
         else if (token == "property")   read_header_property(ls);
-        else if (token == "obj_info")   read_header_text(line, ls, objInfo, 8);
+        else if (token == "obj_info")   read_header_text(line, ls, objInfo, 9);
         else if (token == "end_header") break;
         else return false;
     }

--- a/source/tinyply.cpp
+++ b/source/tinyply.cpp
@@ -73,18 +73,18 @@ bool PlyFile::parse_header(std::istream& is)
             gotMagic = true;
             continue;
         }
-        else if (token == "comment")    read_header_text(line, ls, comments, 7);
+        else if (token == "comment")    read_header_text(line, ls, comments, 8);
         else if (token == "format")     read_header_format(ls);
         else if (token == "element")    read_header_element(ls);
         else if (token == "property")   read_header_property(ls);
-        else if (token == "obj_info")   read_header_text(line, ls, objInfo, 7);
+        else if (token == "obj_info")   read_header_text(line, ls, objInfo, 8);
         else if (token == "end_header") break;
         else return false;
     }
     return true;
 }
 
-void PlyFile::read_header_text(std::string line, std::istream & is, std::vector<std::string> place, int erase)
+void PlyFile::read_header_text(std::string line, std::istream & is, std::vector<std::string>& place, int erase)
 {
     place.push_back((erase > 0) ? line.erase(0, erase) : line);
 }

--- a/source/tinyply.h
+++ b/source/tinyply.h
@@ -306,8 +306,8 @@ namespace tinyply
         void read_header_format(std::istream & is);
         void read_header_element(std::istream & is);
         void read_header_property(std::istream & is);
-        void read_header_text(std::string line, std::istream & is, std::vector<std::string> place, int erase = 0);
-        
+        void read_header_text(std::string line, std::istream &is, std::vector<std::string> &place, int erase = 0);
+
         void read_internal(std::istream & is);
         
         void write_ascii_internal(std::ostringstream & os);


### PR DESCRIPTION
Also, when comments are added to the internal struct, the prefixed space is included.