### PR TITLE
bugfix: include cstring

### DIFF
--- a/source/tinyply.cpp
+++ b/source/tinyply.cpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <type_traits>
 #include <iostream>
+#include <cstring>
 
 using namespace tinyply;
 using namespace std;
@@ -516,7 +517,7 @@ void PlyFile::PlyFileImpl::add_properties_to_element(const std::string & element
         for (auto key : propertyKeys)
         {
             PlyProperty newProp = (listType == Type::INVALID) ? PlyProperty(type, key) : PlyProperty(listType, type, key, listCount);
-            auto result = userData.insert(std::pair<std::string, ParsingHelper>(make_key(elementKey, key), helper));
+            userData.insert(std::pair<std::string, ParsingHelper>(make_key(elementKey, key), helper));
             e.properties.push_back(newProp);
         }
     };

--- a/source/tinyply.h
+++ b/source/tinyply.h
@@ -71,8 +71,8 @@ namespace tinyply
 	struct PlyProperty
 	{
 		PlyProperty(std::istream & is);
-		PlyProperty(Type type, std::string & _name) : propertyType(type), name(_name) {}
-		PlyProperty(Type list_type, Type prop_type, std::string & _name, int list_count) : listType(list_type), propertyType(prop_type), isList(true), name(_name), listCount(list_count) {}
+		PlyProperty(Type type, std::string & _name) : name(_name), propertyType(type) {}
+		PlyProperty(Type list_type, Type prop_type, std::string & _name, int list_count) : name(_name), propertyType(prop_type), isList(true), listType(list_type), listCount(list_count) {}
         std::string name;
         Type propertyType;
         bool isList{ false };

--- a/source/tinyply.h
+++ b/source/tinyply.h
@@ -111,6 +111,6 @@ namespace tinyply
         void add_properties_to_element(const std::string & elementKey, const std::initializer_list<std::string> propertyKeys, const Type type, const size_t count, uint8_t * data, const Type listType, const size_t listCount);
 	};
 
-} // namesapce tinyply
+} // namespace tinyply
 
 #endif // tinyply_h


### PR DESCRIPTION
Hi,

This commit solve a compiler error under g++ (Ubuntu 4.8.4-2ubuntu1~14.04.3) 4.8.4.
I need to `#include <cstring>` to import the std::memcpy function.
Also, I removed a lot of warnings like those if -Wall flag is used
```
In file included from example.cpp:15:0:
tinyply.h: In constructor ‘tinyply::PlyProperty::PlyProperty(tinyply::Type, std::string&)’:
tinyply.h:77:14: warning: ‘tinyply::PlyProperty::propertyType’ will be initialized after [-Wreorder]
         Type propertyType;
              ^
tinyply.h:76:21: warning:   ‘std::string tinyply::PlyProperty::name’ [-Wreorder]
         std::string name;
                     ^
In file included from example.cpp:15:0:
tinyply.h:74:3: warning:   when initialized here [-Wreorder]
   PlyProperty(Type type, std::string & _name) : propertyType(type), name(_name) {}
   ^
In file included from example.cpp:15:0:
tinyply.h: In constructor ‘tinyply::PlyProperty::PlyProperty(tinyply::Type, tinyply::Type, std::string&, int)’:
tinyply.h:79:38: warning: ‘tinyply::PlyProperty::listType’ will be initialized after [-Wreorder]
         Type listType{ Type::INVALID };
```