### PR TITLE
fix initialization order, unused var, make cleanup

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -1,4 +1,8 @@
 all: tinyply-core
 
-tinyply-core: example.cpp
-	$(CXX) tinyply.cpp example.cpp -std=c++11 -o $@
+tinyply-core: tinyply.h tinyply.cpp example.cpp
+	$(CXX) tinyply.cpp example.cpp -std=c++11 -o $@ -Wall -Wpedantic
+
+.PHONY: clean
+clean:
+	rm tinyply-core

--- a/source/tinyply.cpp
+++ b/source/tinyply.cpp
@@ -286,7 +286,7 @@ size_t PlyFile::PlyFileImpl::read_property_binary(const Type t, void * dest, siz
 }
 
 size_t PlyFile::PlyFileImpl::read_property_ascii(const Type t, void * dest, size_t & destOffset, std::istream & is)
-{         
+{
     destOffset += PropertyTable[t].stride;
 
     switch (t)
@@ -342,7 +342,7 @@ void PlyFile::PlyFileImpl::read(std::istream & is)
 
     // Not great, but since we sorted by ptrs on PlyData, need to remap back onto its cursor in the userData table
     for (auto & b : buffers)
-    {   
+    {
         for (auto & entry : userData)
         {
             if (entry.second.data == b && b->buffer.get() == nullptr)
@@ -518,7 +518,7 @@ void PlyFile::PlyFileImpl::add_properties_to_element(const std::string & element
         for (auto key : propertyKeys)
         {
             PlyProperty newProp = (listType == Type::INVALID) ? PlyProperty(type, key) : PlyProperty(listType, type, key, listCount);
-            auto result = userData.insert(std::pair<std::string, ParsingHelper>(make_key(elementKey, key), helper));
+            /* auto result = */userData.insert(std::pair<std::string, ParsingHelper>(make_key(elementKey, key), helper));
             e.properties.push_back(newProp);
         }
     };
@@ -541,7 +541,7 @@ void PlyFile::PlyFileImpl::parse_data(std::istream & is, bool firstPass)
 {
     std::function<size_t(const Type t, void * dest, size_t & destOffset, std::istream & is)> read;
     std::function<size_t(const PlyProperty & p, std::istream & is)> skip;
-    
+
     const auto start = is.tellg();
 
     if (isBinary)

--- a/source/tinyply.h
+++ b/source/tinyply.h
@@ -58,7 +58,7 @@ namespace tinyply
         size_t size;
     public:
         Buffer() {};
-        Buffer(const size_t size) : size(size), data(new uint8_t[size], delete_array()) { alias = data.get(); } // allocating
+        Buffer(const size_t size) : data(new uint8_t[size], delete_array()), size(size) { alias = data.get(); } // allocating
         Buffer(uint8_t * ptr) { alias = ptr; } // non-allocating, fixme: set size?
         uint8_t * get() { return alias; }
         size_t size_bytes() const { return size; }
@@ -74,8 +74,8 @@ namespace tinyply
     struct PlyProperty
     {
         PlyProperty(std::istream & is);
-        PlyProperty(Type type, std::string & _name) : propertyType(type), name(_name) {}
-        PlyProperty(Type list_type, Type prop_type, std::string & _name, int list_count) : listType(list_type), propertyType(prop_type), isList(true), name(_name), listCount(list_count) {}
+        PlyProperty(Type type, std::string & _name) : name(_name), propertyType(type) {}
+        PlyProperty(Type list_type, Type prop_type, std::string & _name, int list_count) : name(_name), propertyType(prop_type), isList(true), listType(list_type), listCount(list_count) {}
         std::string name;
         Type propertyType;
         bool isList{ false };


### PR DESCRIPTION
- Fixes initialization order in `tinyply.h`
- Comments out an unused `auto result` in `tinyply.cpp`
- `Makefile` improvements
    - Add `-Wall` and `-Wpedantic` (what catches the initialization order warnings)
    - Add a clean target
    - Add `tinyply.{h,cpp}` to the dependency list of `tinyply-core` executable so that updates to those files trigger a new build