### PR TITLE
improve cmakelists file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
 set(targets_export_name "${PROJECT_NAME}Targets")
 set(namespace "")
 
+include(GNUInstallDirs)
+
 write_basic_package_version_file(
   "${version_config}"
   VERSION ${PROJECT_VERSION}
@@ -63,9 +65,10 @@ configure_package_config_file(
 
 # Install
 install(TARGETS tinyply EXPORT ${targets_export_name}
-        RUNTIME DESTINATION bin
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib)
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(FILES source/tinyply.h
         DESTINATION include)
 


### PR DESCRIPTION
- add missing header inclusion
  `CMAKE_INSTALL_FULL_INCLUDEDIR`, `CMAKE_INSTALL_FULL_LIBDIR` used in `cmake/Config.cmake.in` are defined in `GNUInstallDirs.cmake`. So an inclusion is necessary. Otherwise, these variables will be set empty in the generated configuration files.
- add INTERFACE_INCLUDE_DIRECTORIES to the exported CMake target