### PR TITLE
Minor fix for building unit tests

### DIFF
--- a/source/tests.cpp
+++ b/source/tests.cpp
@@ -144,7 +144,7 @@ bool parse_ply_file(const std::string & filepath)
     catch (const std::exception & e)
     {
         std::cout << "Caught Exception: " << e.what() << std::endl;
-        REQUIRE(FALSE);
+        REQUIRE(false);
     }
 
     return false;


### PR DESCRIPTION
WIth `cmake .. -DBUILD_TESTS=Y` there is a compilation error.
Easy fix.