### PR TITLE
cmake_minimum_required(VERSION 2.8.12)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 # Compiler requirements
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
We're using cmake 3.21 which is warning us as follows:

```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```
The most obvious solution is to bump tinyply forward to requiring cmake 2.8.12. ([released in Oct 2013](https://cmake.org/pipermail/cmake/2013-October/056020.html))