### PR TITLE
Fix ASCII property list parsing

### DIFF
--- a/source/tinyply.h
+++ b/source/tinyply.h
@@ -888,10 +888,11 @@ void PlyFile::PlyFileImpl::parse_data(std::istream & is, bool firstPass)
             }
             else
             {
+                dummyCount = 0;
                 read_property_ascii(p.listType, f.list_stride, &listSize, dummyCount, sizeof(listSize), _is); // the list size
                 for (size_t i = 0; i < listSize; ++i)
                 {
-                    read_property_ascii(p.propertyType, f.prop_stride, dest + destOffset, destOffset, destOffset, _is);
+                    read_property_ascii(p.propertyType, f.prop_stride, dest + destOffset, destOffset, destSize, _is);
                 }
             }
         };


### PR DESCRIPTION
Currently parsing ASCII property lists fails immediately with the exception "unexpected EOF. malformed file"

This fixes issue #59.