### PR TITLE
Make get_const a const member function

### DIFF
--- a/source/tinyply.h
+++ b/source/tinyply.h
@@ -83,7 +83,7 @@ namespace tinyply
         Buffer(const size_t size) : data(new uint8_t[size], delete_array()), size(size) { alias = data.get(); } // allocating
         Buffer(const uint8_t * ptr): alias(const_cast<uint8_t*>(ptr)) { } // non-allocating, todo: set size?
         uint8_t * get() { return alias; }
-        const uint8_t * get_const() {return const_cast<const uint8_t*>(alias); }
+        const uint8_t * get_const() const {return alias; }
         size_t size_bytes() const { return size; }
     };
 


### PR DESCRIPTION
This will allow get_const to be used when Buffer is accessed via a const reference or const pointer. 
Also remove an unneeded cost cast in the function body.