### PR TITLE
Only set CMAKE_DEBUG_POSTFIX if not already defined by user

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,9 @@ set(PROJECT_VERSION 2.3)
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/source")
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/third-party")
 
-set(CMAKE_DEBUG_POSTFIX "d")
+if(NOT CMAKE_DEBUG_POSTFIX)
+    set(CMAKE_DEBUG_POSTFIX "d")
+endif()
 
 # Library
 set(SHARED_LIB false CACHE BOOL "Build as shared library")


### PR DESCRIPTION
This pull request allows the user to specify his own CMAKE_DEBUG_POSTFIX, if desired. The current behaviour forcefully overrides the variable even when the user has set it e.g. via -DCMAKE_DEBUG_POSTFIX=customPostfix.